### PR TITLE
Updates ExmgSidemenu so that the selected item can be set through prop

### DIFF
--- a/demo/demos/exmg-sidemenu/exmg-sidemenu-demo.ts
+++ b/demo/demos/exmg-sidemenu/exmg-sidemenu-demo.ts
@@ -1,21 +1,26 @@
-import {LitElement, html, css} from 'lit';
-import {property, customElement} from 'lit/decorators.js';
-import {classMap} from 'lit/directives/class-map.js';
-import {style as sidemenuStyles} from '@exmg/exmg-sidemenu/styles/exmg-sidemenu-styles-css.js';
-import {style as themeStyles} from '@exmg/exmg-sidemenu/styles/theme-styles-css.js';
+import { LitElement, html, css } from 'lit';
+import { property, customElement } from 'lit/decorators.js';
+import { classMap } from 'lit/directives/class-map.js';
+import { style as sidemenuStyles } from '@exmg/exmg-sidemenu/styles/exmg-sidemenu-styles-css.js';
+import { style as themeStyles } from '@exmg/exmg-sidemenu/styles/theme-styles-css.js';
 import '@exmg/exmg-sidemenu/exmg-sidemenu.js';
 import '@exmg/exmg-sidemenu/exmg-sidemenu-header.js';
 import '@exmg/exmg-sidemenu/exmg-sidemenu-badge.js';
 import '@material/mwc-icon-button/mwc-icon-button.js';
 import '@polymer/paper-item/paper-item.js';
 import '@exmg/exmg-tooltip/exmg-tooltip.js';
+import '@exmg/exmg-button/exmg-button.js';
 import '@polymer/app-layout/app-drawer/app-drawer.js';
 import '@polymer/app-layout/app-toolbar/app-toolbar.js';
 
-import {menu} from './menu.js';
-import {isItemGroup, MenuItem, MenuGroupItem, MenuItemOrGroupItem} from '@exmg/exmg-sidemenu/exmg-sidemenu-types.js';
+import { menu } from './menu.js';
+import { isItemGroup, MenuItem, MenuGroupItem, MenuItemOrGroupItem } from '@exmg/exmg-sidemenu/exmg-sidemenu-types.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
 
-export const installMediaQueryWatcher = (mediaQuery: string, layoutChangedCallback: (mediaQueryMatches: boolean) => void) => {
+export const installMediaQueryWatcher = (
+  mediaQuery: string,
+  layoutChangedCallback: (mediaQueryMatches: boolean) => void,
+) => {
   const mql = window.matchMedia(mediaQuery);
   mql.addListener((e) => layoutChangedCallback(e.matches));
   layoutChangedCallback(mql.matches);
@@ -23,20 +28,23 @@ export const installMediaQueryWatcher = (mediaQuery: string, layoutChangedCallba
 
 @customElement('exmg-sidemenu-demo')
 export class SidemenuDemo extends LitElement {
-  @property({type: Array})
+  @property({ type: Array })
   menu: [] | undefined;
 
-  @property({type: Boolean})
+  @property({ type: Boolean })
   debug = true;
 
-  @property({type: Boolean, reflect: true})
+  @property({ type: Boolean, reflect: true })
   narrow = false;
 
-  @property({type: Boolean})
+  @property({ type: Boolean })
   collapsed = false;
 
-  @property({type: Boolean})
+  @property({ type: Boolean })
   drawerOpened = true;
+
+  @property({ type: String })
+  selectedItemMenu?: String;
 
   static styles = [
     sidemenuStyles,
@@ -102,7 +110,9 @@ export class SidemenuDemo extends LitElement {
     return html`
       <a href=${this.debug ? '#' : i.path} data-path=${i.path} tabindex="-1" class="menu-item solo">
         <paper-item data-path=${i.path} role="menuitem">
-          ${i.iconPath ? html`<svg height="24" viewBox="0 0 24 24" width="24"><path d="${i.iconPath}"></path></svg>` : i.icon}
+          ${i.iconPath
+            ? html`<svg height="24" viewBox="0 0 24 24" width="24"><path d="${i.iconPath}"></path></svg>`
+            : i.icon}
           <span class="title">${i.title}</span>
           ${i.badge
             ? html`<exmg-sidemenu-badge ?collapsed=${this.collapsed}
@@ -117,14 +127,17 @@ export class SidemenuDemo extends LitElement {
   }
 
   private renderMenu() {
-    return html` ${(menu || []).map((i: MenuItemOrGroupItem) => (isItemGroup(i) ? this.renderGroupItem(i) : this.renderItem(i)))} `;
+    return html`
+      ${(menu || []).map((i: MenuItemOrGroupItem) => (isItemGroup(i) ? this.renderGroupItem(i) : this.renderItem(i)))}
+    `;
   }
 
   private openChanged(e: CustomEvent) {
     this.drawerOpened = e.detail.value;
   }
 
-  private _handleSelectedChanged() {
+  private _handleSelectedChanged(e: CustomEvent) {
+    this.selectedItemMenu = e.detail;
     if (this.narrow) {
       this.drawerOpened = false;
     }
@@ -136,6 +149,10 @@ export class SidemenuDemo extends LitElement {
 
   private _handleMenuClick() {
     this.drawerOpened = !this.drawerOpened;
+  }
+
+  setItem() {
+    this.selectedItemMenu = 'content/';
   }
 
   renderFooterButton() {
@@ -158,7 +175,7 @@ export class SidemenuDemo extends LitElement {
   }
 
   render() {
-    const classes = {collapsed: this.collapsed, narrow: this.narrow};
+    const classes = { collapsed: this.collapsed, narrow: this.narrow };
 
     return html`
       <app-drawer
@@ -171,11 +188,11 @@ export class SidemenuDemo extends LitElement {
         @opened-changed="${this.openChanged}"
       >
         <exmg-sidemenu
-          selected="rooms/"
           ?collapsed=${this.collapsed}
           @collapsed=${this._handleCollapsed}
           @selected-changed=${this._handleSelectedChanged}
           ?narrow=${this.narrow}
+          selected="${ifDefined(this.selectedItemMenu)}"
         >
           <exmg-sidemenu-header slot="header" ?collapsed=${this.collapsed}></exmg-sidemenu-header>
           ${this.renderMenu()} ${this.renderFooterButton()}
@@ -187,29 +204,34 @@ export class SidemenuDemo extends LitElement {
           <mwc-icon-button icon="menu" ?hidden=${!this.narrow} @click=${this._handleMenuClick}></mwc-icon-button>
         </app-toolbar>
         <main role="main">
+          <exmg-button unelevated @click=${this.setItem}>Set Content as selected item</exmg-button>
           <p>
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
-            enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor
-            in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident,
-            sunt in culpa qui officia deserunt mollit anim id est laborum.
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et
+            dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex
+            ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat
+            nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit
+            anim id est laborum.
           </p>
           <p>
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
-            enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor
-            in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident,
-            sunt in culpa qui officia deserunt mollit anim id est laborum.
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et
+            dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex
+            ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat
+            nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit
+            anim id est laborum.
           </p>
           <p>
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
-            enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor
-            in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident,
-            sunt in culpa qui officia deserunt mollit anim id est laborum.
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et
+            dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex
+            ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat
+            nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit
+            anim id est laborum.
           </p>
           <p>
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
-            enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor
-            in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident,
-            sunt in culpa qui officia deserunt mollit anim id est laborum.
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et
+            dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex
+            ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat
+            nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit
+            anim id est laborum.
           </p>
         </main>
       </article>

--- a/packages/exmg-sidemenu/exmg-sidemenu-base.ts
+++ b/packages/exmg-sidemenu/exmg-sidemenu-base.ts
@@ -1,6 +1,6 @@
-import {html} from 'lit';
-import {ExmgElement, observer} from '@exmg/lit-base/index.js';
-import {property} from 'lit/decorators.js';
+import { html } from 'lit';
+import { ExmgElement, observer } from '@exmg/lit-base/index.js';
+import { property } from 'lit/decorators.js';
 import '@polymer/paper-listbox';
 
 export const chevronLeftIcon = html`
@@ -16,31 +16,28 @@ export const settingsIcon = html`
 `;
 
 export class ExmgSidemenuBase extends ExmgElement {
-  @property({type: Boolean, reflect: true})
+  @property({ type: Boolean, reflect: true })
   @observer(function (this: ExmgElement, collapsed: boolean) {
-    this.dispatchEvent(new CustomEvent('collapsed', {bubbles: false, composed: true, detail: collapsed}));
+    this.dispatchEvent(new CustomEvent('collapsed', { bubbles: false, composed: true, detail: collapsed }));
   })
   collapsed = false;
 
   /**
    * Contains the path of the selected menu item
    */
-  @property({type: String})
-  @observer(function (this: ExmgElement, selected: string) {
-    this.dispatchEvent(new CustomEvent('selected-changed', {bubbles: false, composed: true, detail: selected}));
-  })
+  @property({ type: String, reflect: true })
   selected!: string;
 
   /**
    *  Disable collapse functionailty
    */
-  @property({type: Boolean, reflect: true, attribute: 'disable-collapse'})
+  @property({ type: Boolean, reflect: true, attribute: 'disable-collapse' })
   disableCollapse = false;
 
   /**
    *  Menu has footer item
    */
-  @property({type: Boolean, reflect: true, attribute: 'footer-item'})
+  @property({ type: Boolean, reflect: true, attribute: 'footer-item' })
   footerItem = false;
 
   firstUpdated() {
@@ -92,8 +89,9 @@ export class ExmgSidemenuBase extends ExmgElement {
   /**
    *  Update the selected value
    */
-  _handleSelectionChange(e: CustomEvent<{value: string}>) {
+  _handleSelectionChange(e: CustomEvent<{ value: string }>) {
     this.selected = e.detail.value;
+    this.dispatchEvent(new CustomEvent('selected-changed', { bubbles: false, composed: true, detail: e.detail.value }));
   }
 
   /**

--- a/packages/exmg-sidemenu/exmg-sidemenu-base.ts
+++ b/packages/exmg-sidemenu/exmg-sidemenu-base.ts
@@ -91,7 +91,7 @@ export class ExmgSidemenuBase extends ExmgElement {
    */
   _handleSelectionChange(e: CustomEvent<{ value: string }>) {
     this.selected = e.detail.value;
-    this.dispatchEvent(new CustomEvent('selected-changed', { bubbles: false, composed: true, detail: e.detail.value }));
+    this.fire('selected-change', this.selected, true);
   }
 
   /**


### PR DESCRIPTION
# Why this pull-request
I faced an issue in Livery. When I was redirecting the user to page B from page A, the selected menu item would stay on A. 

I then tried to fix this in the AppLayoutBase in PlaytwoCore that manages the item selection through a property only to realize that it was buggy. 
What happened was that the ExmgSidemenu `selectedItem` property had an observer that would throw an event any time the selected prop was changing. In the Core, we would listen to that event to set the item. Resulting in a weird loop of props. 

# How does this work
I simply removed the observer and set the event when `paper-listbox` throw the event itself. I guess it wasn't bubbling.